### PR TITLE
Linked "our previous work" and "announcement section" in the same tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,8 +24,8 @@
                 <li><a href="#home">Home</a></li>
                 <li><a href="#about-us">About Us</a></li>
                 <li><a href="#services">Services</a></li>
-                <li><a href="./previouswork.html" target="_blank">Previous Work</a></li>
-                <li><a href="./announcement.html" target="_blank">Announcements</a></li>
+                <li><a href="./previouswork.html" >Previous Work</a></li>
+                <li><a href="./announcement.html" >Announcements</a></li>
                 <li><a href="#team">Mentors</a></li>
                 <li><a href="#contact">Contact</a></li>
             </ul>


### PR DESCRIPTION
Fixes #6 

Linked "our previous work" and "announcement section" in the same tab

removed target="_blank"

https://thementorshipclub.vercel.app/