### PR TITLE
Fix FAQ answer in dark mode 

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1534,7 +1534,8 @@ body.dark-mode .faq-question:hover {
   max-height: 0;
   overflow: hidden;
   transition: all 0.4s ease;
-  background: #fffaf8;
+  /* background: #fffaf8; */
+  background: var(--light-bg); 
   padding: 0 20px;
 }
 
@@ -1549,7 +1550,11 @@ body.dark-mode .faq-question:hover {
 }
 
 body.dark-mode .faq-answer p {
-  color: black;
+  color: var(--text-dark);  
+}
+
+body.dark-mode .faq-answer {
+  background: var(--card-bg); 
 }
 
 /* GENERAL DARK MODE FALLBACKS*/


### PR DESCRIPTION
<img width="1015" height="244" alt="Screenshot 2025-11-15 at 3 32 35 PM" src="https://github.com/user-attachments/assets/7df54e8f-06b4-4fb2-979d-12057b430050" />

Fixes #103 